### PR TITLE
Draft: Arm64 support for version 4 series

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
 conda_forge_output_validation: true
 conda_build:
   pkg_format: '2'
+build_platform:
+  osx_arm64: osx_64
+test: native_and_emulated

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 set -e
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* .
+
 autoreconf --install  # autotools based install officially recommended for now it seems...
 CFLAGS="-O2 -g $CFLAGS" ./configure --prefix="$PREFIX" --enable-shared
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('libxc', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - make                       # [linux]
     - cmake                      # [win]
     - ninja                      # [win]
+    - gnuconfig                  # [unix
 
 test:
   commands:


### PR DESCRIPTION
https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Adding support for Arm64 build to the version 4 series.

<!--
Please add any other relevant info below:
-->
Following the directions here: https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/
It seems that even though libxc is listed on the pinning feed: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/migrations/osx_arm64.txt
This doesn't apply to the old versions series